### PR TITLE
Add sleep to travis.yml for intermittent mongo bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     packages:
     - mongodb-org-server
 before_script:
-- mongod --version
+- sleep 15
 deploy:
     provider: heroku
     app: afternoon-ridge-54801


### PR DESCRIPTION
See https://docs.travis-ci.com/user/database-setup/#MongoDB-does-not-immediately-accept-connections
